### PR TITLE
Enhancements to MultilineAttributeDecorator

### DIFF
--- a/src/decorators/MultilineAttributeDecorator/DiagramDesigner/MultilineAttributeDecorator.DiagramDesignerWidget.js
+++ b/src/decorators/MultilineAttributeDecorator/DiagramDesigner/MultilineAttributeDecorator.DiagramDesignerWidget.js
@@ -310,6 +310,21 @@ define([
                         self.client.setAttribute(self.nodeId, desc.name, $(this).val());
                     }
                 })
+                .on('drop', function (event) {
+                    var nodeObj = self.client.getNode(self.nodeId),
+                        file = event.originalEvent.dataTransfer.files[0],
+                        reader = new FileReader();
+
+                    event.preventDefault();
+                    reader.onload = function (event) {
+                        if (event.target.result !== self.fields[desc.name].value &&
+                            nodeObj && nodeObj.isReadOnly() === false) {
+                            self.client.setAttribute(self.nodeId, desc.name, event.target.result);
+                        }
+
+                    };
+                    reader.readAsText(file);
+                })
                 .css({
                     textAlign: this.config.textAlign,
                 })
@@ -422,8 +437,12 @@ define([
 
         var self = this,
             style = {
-                backgroundColor: this.fillColor ? this.fillColor : '',
+                backgroundColor: this.borderColor ? this.borderColor : '',
                 borderColor: this.borderColor ? this.borderColor : '',
+                color: this.textColor ? this.textColor : '',
+            },
+            contentStyle = {
+                backgroundColor: this.fillColor ? this.fillColor : '',
                 color: this.textColor ? this.textColor : '',
             };
 
@@ -431,7 +450,7 @@ define([
 
         Object.keys(self.fields)
             .forEach(function (attrName) {
-                self.fields[attrName].el.find('textarea').css(style);
+                self.fields[attrName].el.find('textarea').css(contentStyle);
             });
     };
 

--- a/src/decorators/MultilineAttributeDecorator/DiagramDesigner/MultilineAttributeDecorator.DiagramDesignerWidget.js
+++ b/src/decorators/MultilineAttributeDecorator/DiagramDesigner/MultilineAttributeDecorator.DiagramDesignerWidget.js
@@ -24,8 +24,8 @@ define([
         WIDTH_REG_KEY = 'decoratorWidth',
         MIN_WIDTH = 120,
         MIN_HEIGHT = 80,
-        NO_DROP_COLOR = 'rgb(199,10,10)',
-        ALLOW_DROP_COLOR = 'rgb(10,199,10)';
+        NO_DROP_COLOR = 'rgba(255, 0, 0, 0.1)',
+        ALLOW_DROP_COLOR = 'rgba(0, 255, 0, 0.1)';
 
     function MultilineAttributeDecorator(options) {
         var opts = _.extend({}, options);
@@ -327,6 +327,7 @@ define([
                 .on('drop', function (event) {
                     var element = this;
                     event.preventDefault();
+                    self._renderColors();
                     if (self._canAcceptTarget(event.originalEvent.dataTransfer)) {
                         self._getDropContentAsString(event.originalEvent.dataTransfer, function (content) {
                             // var nodeObj = self.client.getNode(self.nodeId);

--- a/src/decorators/MultilineAttributeDecorator/PartBrowser/MultilineAttributeDecorator.PartBrowserWidget.js
+++ b/src/decorators/MultilineAttributeDecorator/PartBrowser/MultilineAttributeDecorator.PartBrowserWidget.js
@@ -83,7 +83,7 @@ define([
         ModelDecoratorCore.prototype._getNodeColorsFromRegistry.apply(this);
 
         var style = {
-            backgroundColor: this.fillColor ? this.fillColor : '',
+            backgroundColor: this.borderColor ? this.borderColor : '',
             borderColor: this.borderColor ? this.borderColor : '',
             color: this.textColor ? this.textColor : '',
         };


### PR DESCRIPTION
- borderColor now handled as the background color of the whole box, while fillColor is used as the backgroundColor of individual textareas
- file drop is now handled and replaces the content of the textarea on drop (no blob involvement) *does not work on microsoft edge